### PR TITLE
fix: run fetch cleanup after network errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "DIST_FOLDER": "../bitgesell-wallet-dist"
   },
   "scripts": {
-    "test": "eslint 'src/*.js'",
+    "test": "eslint 'src/*.js' test/fetch_query_cleanup_test.js && node test/fetch_query_cleanup_test.js",
     "local-server": "IP=$npm_package_config_IP PORT=$npm_package_config_PORT node local-server.js",
     "start": "npm test && npm run local-server",
     "build": "./build.sh $npm_package_config_DIST_FOLDER",

--- a/src/api.js
+++ b/src/api.js
@@ -28,6 +28,7 @@ const fetchQuery = (url, callback, fetchParams = null, errorFunc = null, callbac
 				}
 			})
 			.catch((error) => {
+				if (callbackAlways) callbackAlways();
 				if (error == 'TypeError: Failed to fetch') error += '<br><br>Maybe it is CORS! Check please <a class="btn btn-sm btn-info" target="_blank" href="https://github.com/epexa/bitgesell-wallet-dist/blob/master/CORS.md#cors">manual here.</a>';
 				Swal.fire({
 					showCloseButton: true,

--- a/test/fetch_query_cleanup_test.js
+++ b/test/fetch_query_cleanup_test.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'api.js'), 'utf8');
+
+const createContext = (fetchImpl) => {
+	const swalCalls = [];
+	const context = {
+		fetch: fetchImpl,
+		Swal: {
+			fire: (params) => {
+				swalCalls.push(params);
+			},
+		},
+	};
+	context.global = context;
+	vm.createContext(context);
+	vm.runInContext(`${source}\nthis.fetchQuery = fetchQuery;`, context);
+	context.swalCalls = swalCalls;
+	return context;
+};
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+const testRejectedFetchRunsCleanupBeforeAlert = async () => {
+	const events = [];
+	// Matches the string branch already used by the wallet's CORS-help path.
+	// eslint-disable-next-line prefer-promise-reject-errors
+	const context = createContext(() => Promise.reject('TypeError: Failed to fetch'));
+
+	context.Swal.fire = (params) => {
+		events.push('alert');
+		context.swalCalls.push(params);
+	};
+
+	context.fetchQuery(
+		'https://node.example/rpc',
+		() => events.push('success'),
+		null,
+		null,
+		() => events.push('cleanup'),
+	);
+
+	await flushPromises();
+	await flushPromises();
+
+	assert.deepStrictEqual(events, [ 'cleanup', 'alert' ]);
+	assert.strictEqual(context.swalCalls.length, 1);
+	assert.match(context.swalCalls[0].html, /Maybe it is CORS!/);
+};
+
+const testErrorResponseRunsCleanupOnce = async () => {
+	let cleanupCount = 0;
+	const context = createContext(() => Promise.resolve({
+		json: () => Promise.resolve({ error: { message: 'bad tx' } }),
+	}));
+
+	context.fetchQuery(
+		'https://node.example/rpc',
+		() => assert.fail('success callback should not run for error response'),
+		null,
+		() => ({ message: 'mapped error' }),
+		() => { cleanupCount++; },
+	);
+
+	await flushPromises();
+	await flushPromises();
+
+	assert.strictEqual(cleanupCount, 1);
+	assert.strictEqual(context.swalCalls.length, 1);
+	assert.strictEqual(context.swalCalls[0].html, 'mapped error');
+};
+
+(async () => {
+	await testRejectedFetchRunsCleanupBeforeAlert();
+	await testErrorResponseRunsCleanupOnce();
+	console.log('fetchQuery cleanup tests passed');
+})().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Ensures `fetchQuery` runs its `callbackAlways` cleanup when `fetch()` rejects before a JSON response is available.
- Prevents send-form callers from staying disabled after network/CORS/RPC connectivity failures.

## Why
`send()` disables the form fieldset before submitting `sendrawtransaction` and relies on `callbackAlways` to re-enable it. The success/error-response path already called the cleanup, but the `.catch()` path only showed the SweetAlert error. A rejected network request could therefore leave the wallet send form disabled until page refresh.

## Validation
- `npm test` passed
- `git diff --check` clean

Related Bitgesell bounty/improvement program: BitgesellOfficial/bitgesell#81 and BitgesellOfficial/bitgesell#39.

Payout address, if accepted: `0x4a76c7E64C08cF29B59eFC640b4ada97A270d428` (EVM/USDT-compatible).

### Follow-up hardening (2026-06-08)
- Added `test/fetch_query_cleanup_test.js`, a focused Node/vm regression harness that proves a rejected `fetch()` runs `callbackAlways` exactly before rendering the SweetAlert error and that JSON error responses still run cleanup exactly once.
- Expanded `npm test` to run ESLint on the regression harness plus the executable cleanup tests.

Validation after follow-up commit `a34b4c0`:
- `npm test`
- `node --check test/fetch_query_cleanup_test.js`
- `git diff --check`
